### PR TITLE
Daother 9339 - add mechanism to calculate structure complexity

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,8 @@ platform=
 skip_install = false
 recreate = true
 alwayscopy=true
-usedevelop=true
+# We need wwpdb.utils.dp installed for proper testing -- but running tox in order breaks - oh well
+# usedevelop=true
 deps = -r requirements.txt
 commands =
     echo "Starting {envname}"
@@ -128,7 +129,8 @@ platform=
        linux: linux
 recreate = true
 alwayscopy=true
-usedevelop=true
+# We need wwpdb.utils.dp installed for proper testing
+#usedevelop=true
 deps =
     coverage
     -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -62,8 +62,7 @@ platform=
 skip_install = false
 recreate = true
 alwayscopy=true
-# We need wwpdb.utils.dp installed for proper testing -- but running tox in order breaks - oh well
-# usedevelop=true
+usedevelop=true
 deps = -r requirements.txt
 commands =
     echo "Starting {envname}"
@@ -129,8 +128,7 @@ platform=
        linux: linux
 recreate = true
 alwayscopy=true
-# We need wwpdb.utils.dp installed for proper testing
-#usedevelop=true
+usedevelop=true
 deps =
     coverage
     -r requirements.txt

--- a/wwpdb/utils/dp/PdbxModelComplexity.py
+++ b/wwpdb/utils/dp/PdbxModelComplexity.py
@@ -1,0 +1,164 @@
+"""Functionailty to calculate the complexit of coordinate model"""
+
+import argparse
+import os
+import logging
+import sys
+
+from mmcif.io.IoAdapterCore import IoAdapterCore as IoAdapter
+from mmcif.api.PdbxContainers import DataContainer
+from mmcif.api.DataCategory import DataCategory
+
+logger = logging.getLogger(__name__)
+
+
+class PdbxModelCompletity:
+    def __init__(self, threshold=1e6):
+        self.__data = {}
+        self.__threshold = threshold
+
+    def calculate(self, fpath):
+        """Calculates complexity of coordinate file in fpath.  Returns True on success.  Returns False if file does not exist"""
+
+        if not os.path.exists(fpath):
+            logger.error("Filename %s does not exist", fpath)
+            return False
+
+        io = IoAdapter()
+        cL = io.readFile(fpath, selectList=["entity", "pdbx_struct_assembly"])
+
+        if not cL or len(cL) < 1:
+            logger.error("Error processing complexity %s", fpath)
+            return False
+
+        b0 = cL[0]
+
+        # Determine oligo count - use first row of pdbx_struct_assembly if present
+        oligo_count = 1
+        if b0.exists("pdbx_struct_assembly"):
+            cObj = b0.getObj("pdbx_struct_assembly")
+
+            if "oligomeric_count" in cObj.getAttributeList():
+                val = cObj.getValueOrDefault("oligomeric_count", rowIndex=0, defaultValue="1")
+                try:
+                    valI = int(val)
+                    oligo_count = valI
+                except ValueError:
+                    pass
+
+        # Calculate complexity
+        entry_complexity = 0
+        non_poly_complexity = 0
+        polymer_complexity = 0
+
+        if b0.exists("entity"):
+            cObj = b0.getObj("entity")
+
+            # Ensure real data
+            for attr in ["type", "pdbx_number_of_molecules", "formula_weight"]:
+                if attr not in cObj.getAttributeList():
+                    logger.error("Entity category missing attribute %s", attr)
+                    return False
+
+            for row in range(cObj.getRowCount()):
+                etype = cObj.getValueOrDefault("type", row, "unknown")
+                num_mol = cObj.getValueOrDefault("pdbx_number_of_molecules", row, "1")
+                fw = cObj.getValueOrDefault("formula_weight", row, "unknown")
+
+                try:
+                    num_mol_int = int(num_mol)
+                    fw_val = float(fw)
+                except ValueError:
+                    logger.error("Error converting values %s %s", num_mol, fw)
+
+                if etype == "polymer":
+                    entity_complexity = num_mol_int * fw_val * oligo_count
+                    entry_complexity += entity_complexity
+                    polymer_complexity += entity_complexity
+                else:
+                    # water, ligands, branched chain carbo, etc
+                    entity_complexity = num_mol_int * fw_val
+                    entry_complexity += entity_complexity
+                    non_poly_complexity += entity_complexity
+
+            is_complex = True if entry_complexity > self.__threshold else False
+
+            self.__data = {
+                "is_complex": is_complex,
+                "entry_complexity": entry_complexity,
+                "polymer_complexity": polymer_complexity,
+                "non_poly_complexity": non_poly_complexity,
+            }
+
+            return True
+
+    def write_output(self, fpath):
+        """Writes out the"""
+
+        c0 = DataContainer("complexity")
+
+        is_complex = str(self.__data.get("is_complex", False))
+        entry_complexity = str(self.__data.get("entry_complexity", 0))
+        polymer_complexity = str(self.__data.get("polymer_complexity", 0))
+        non_poly_complexity = str(self.__data.get("non_poly_complexity", 0))
+        threshold = "{:.2e}".format(self.__threshold)
+
+        attrlist = [
+            "is_complex",
+            "entry_complexity",
+            "polymer_complexity",
+            "non_poly_complexity",
+            "complex_threshold",
+        ]
+        data = [
+            [
+                is_complex,
+                entry_complexity,
+                polymer_complexity,
+                non_poly_complexity,
+                threshold,
+            ]
+        ]
+
+        cat = DataCategory("pdbx_complexity", attrlist, data)
+        c0.append(cat)
+
+        clist = [c0]
+
+        io = IoAdapter()
+        io.writeFile(fpath, clist)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(
+        prog="PdbxModelComplexity.py",
+        description="Calculates the complexity of a model file and outputs a CIF file with information",
+    )
+    parser.add_argument("--model", required=True, help="model file to calculate complexity")
+    parser.add_argument("--output", required=True, help="output file to record complexity")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=1e6,
+        help="threshold value to use as cutoff (1.0E+6 default)",
+    )
+    args = parser.parse_args()
+
+    threshold = args.threshold
+    modelpath = args.model
+    output = args.output
+
+    pmc = PdbxModelCompletity(threshold=threshold)
+    ok = pmc.calculate(modelpath)
+    if ok:
+        pmc.write_output(output)
+    else:
+        print("Could not parse input file %s" % modelpath)
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/wwpdb/utils/dp/RcsbDpUtility.py
+++ b/wwpdb/utils/dp/RcsbDpUtility.py
@@ -360,6 +360,7 @@ class RcsbDpUtility(object):
             "em-density-bcif",
             "xray-density-bcif",
             "centre-of-mass",
+            "annot-complexity",
         ]
 
         self.__sequenceOps = ["seq-blastp", "seq-blastn", "fetch-uniprot", "fetch-gb", "format-uniprot", "format-gb", "backup-seqdb"]
@@ -1465,6 +1466,16 @@ class RcsbDpUtility(object):
             cmd += "; {}".format(self.__site_config_command)
 
             cmd += " ; python -m wwpdb.utils.dp.CentreOfMass {}".format(" ".join(cmd_args))
+            cmd += " > " + tPath + " 2>&1 ; cat " + tPath + " >> " + lPath
+
+        elif op == "annot-complexity":
+            cmd_path = "python -m wwpdb.utils.dp.PdbxModelComplexity"
+
+            cmd += "; " + cmd_path + " --model " + iPath + " --output " + oPath
+
+            if "threshold" in self.__inputParamDict:
+                cmd += " --threshold " + self.__inputParamDict["threshold"]
+
             cmd += " > " + tPath + " 2>&1 ; cat " + tPath + " >> " + lPath
 
         elif op == "annot-dcc-report":

--- a/wwpdb/utils/tests-dp/PdbxModelComplexityTests.py
+++ b/wwpdb/utils/tests-dp/PdbxModelComplexityTests.py
@@ -1,0 +1,98 @@
+##
+# File:    PdbxModelComplexityTests.py
+# Author:  E.Peisach
+# Date:    2-Sep-2021
+# Version: 0.001
+#
+# Update:
+##
+"""
+Test cases for CentreOfMass calculation
+
+"""
+import logging
+import os
+import sys
+import unittest
+
+if __package__ is None or __package__ == "":
+    from os import path
+
+    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+    from commonsetup import TESTOUTPUT, TOPDIR, modified_environ  # pylint: disable=import-error
+else:
+    from .commonsetup import TESTOUTPUT, TOPDIR
+
+from wwpdb.utils.config.ConfigInfo import getSiteId
+from wwpdb.utils.dp.RcsbDpUtility import RcsbDpUtility
+from mmcif.io.IoAdapterCore import IoAdapterCore
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s]-%(module)s.%(funcName)s: %(message)s")
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class ModelComplexityTests(unittest.TestCase):
+    def setUp(self):
+        self.__tmpPath = TESTOUTPUT
+        #
+        self.__siteId = getSiteId(defaultSiteId=None)
+        logger.info("\nTesting with site environment for:  %s\n", self.__siteId)
+        #
+        self.__testFilePath = os.path.join(TOPDIR, "wwpdb", "mock-data", "MODELS")
+        self.__testFileCif = "1kip.cif"
+
+    def tearDown(self):
+        pass
+
+    def testModelComplexity(self):
+        """ """
+
+        outfile = os.path.join(TESTOUTPUT, "complexity.cif")
+        if os.path.exists(outfile):
+            os.remove(outfile)
+
+        with modified_environ(PYTHONPATH=TOPDIR):
+            dp = RcsbDpUtility(tmpPath=self.__tmpPath, siteId=self.__siteId, verbose=True)
+            cifPath = os.path.join(self.__testFilePath, self.__testFileCif)
+            dp.imp(cifPath)
+
+            dp.op("annot-complexity")
+            dp.exp(outfile)
+            dp.expLog(os.path.join(TESTOUTPUT, "complexity.log"))
+        self.assertTrue(os.path.exists(outfile))
+        self.assertFalse(self.getcomplex(outfile))
+
+    def testModelComplexityThreshold(self):
+        """Retrieve complexity with lower threshold"""
+
+        outfile = os.path.join(TESTOUTPUT, "complexity2.cif")
+        if os.path.exists(outfile):
+            os.remove(outfile)
+
+        with modified_environ(PYTHONPATH=TOPDIR):
+            dp = RcsbDpUtility(tmpPath=self.__tmpPath, siteId=self.__siteId, verbose=True)
+            cifPath = os.path.join(self.__testFilePath, self.__testFileCif)
+            dp.imp(cifPath)
+            dp.addInput("threshold", "1000")
+            dp.op("annot-complexity")
+            dp.exp(outfile)
+            dp.expLog(os.path.join(TESTOUTPUT, "complexity2.log"))
+        self.assertTrue(os.path.exists(outfile))
+        self.assertTrue(self.getcomplex(outfile))
+
+    def getcomplex(self, fpath):
+        """Retrieve complexity"""
+        io = IoAdapterCore()
+        cL = io.readFile(fpath)
+        self.assertIsInstance(cL, list)
+        b0 = cL[0]
+        cObj = b0.getObj("pdbx_complexity")
+        comp = cObj.getValue("is_complex")
+        ret = True if comp == "True" else False
+        return ret
+
+
+if __name__ == "__main__":
+    # Run all tests --
+    unittest.main()

--- a/wwpdb/utils/tests-dp/commonsetup.py
+++ b/wwpdb/utils/tests-dp/commonsetup.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import contextlib
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 TOPDIR = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
@@ -40,3 +41,35 @@ else:
 class commonsetup(object):
     def __init__(self):
         pass
+
+
+# From https://stackoverflow.com/questions/2059482/temporarily-modify-the-current-processs-environment
+@contextlib.contextmanager
+def modified_environ(*remove, **update):
+    """
+    Temporarily updates the ``os.environ`` dictionary in-place.
+
+    The ``os.environ`` dictionary is updated in-place so that the modification
+    is sure to work in all situations.
+
+    :param remove: Environment variables to remove.
+    :param update: Dictionary of environment variables and values to add/update.
+    """
+    env = os.environ
+    update = update or {}
+    remove = remove or []
+
+    # List of environment variables being updated or removed.
+    stomped = (set(update.keys()) | set(remove)) & set(env.keys())
+    # Environment variables and values to restore on exit.
+    update_after = {k: env[k] for k in stomped}
+    # Environment variables and values to remove on exit.
+    remove_after = frozenset(k for k in update if k not in env)
+
+    try:
+        env.update(update)
+        [env.pop(k, None) for k in remove]  # pylint: disable=expression-not-assigned
+        yield
+    finally:
+        env.update(update_after)
+        [env.pop(k) for k in remove_after]  # pylint: disable=expression-not-assigned


### PR DESCRIPTION
Add task annot-complexity to RcsbDpUtility with tests.

Testing needed to set PYTHONPATH as python interpreter that is executed does not have support code installed.

Update mock-data to latest as well.