### PR TITLE
Fix bond_dist output filename: bond_dist.err -> bond_dist.log

### DIFF
--- a/wwpdb/utils/dp/RcsbDpUtility.py
+++ b/wwpdb/utils/dp/RcsbDpUtility.py
@@ -4100,7 +4100,7 @@ class RcsbDpUtility:
                 link_radii = self.__inputParamDict["cc_link_radii"]
                 cmd += " -link_radii " + link_radii
             cmd += " > " + tPath + " 2>&1 ; cat " + tPath + " >> " + lPath
-            cmd += " ; cat bond_dist.err" + " >> " + lPath
+            cmd += " ; cat bond_dist.log" + " >> " + lPath
         elif (op == "chem-comp-assign") or (op == "chem-comp-assign-skip") or (op == "chem-comp-assign-exact"):
             # set up
             #


### PR DESCRIPTION
**Fix bond_dist log filename in chem-comp-link step**

The `bond_dist` binary writes its output to `bond_dist.log`, but the command in `__rcsbStep` was trying to `cat bond_dist.err` — a file that doesn't exist.

**Impact:**
- **With `set -e`** (e.g. SLURM via `RunRemote`): `cat bond_dist.err` exits non-zero, causing the entire `chem-comp-link` step to fail. The workflow retries 3 times before marking the step as FAILED — even though `bond_dist` itself succeeded.
- **Without `set -e`** (e.g. direct VM execution): the `cat` fails silently, so `chem-comp-link` appears to succeed but the bond distance log data is never captured.

**Fix:**
Changed `bond_dist.err` → `bond_dist.log` on the `cat` command that appends output to the step log file.