### PR TITLE
Feature/singularity support

### DIFF
--- a/wwpdb/utils/dp/RcsbDpUtility.py
+++ b/wwpdb/utils/dp/RcsbDpUtility.py
@@ -432,6 +432,7 @@ class RcsbDpUtility:
         self.__use_singularity = False
         self.__singularity_image = None
         self.__singularity_bind_paths = []
+        self.__partition = None
 
         self.__cI = ConfigInfo(self.__siteId)
         self.__cICommon = ConfigInfoAppCommon(self.__siteId)
@@ -514,6 +515,15 @@ class RcsbDpUtility:
             self.__singularity_bind_paths = [p.strip() for p in bind_paths.split(",")]
         else:
             logger.error("bind_paths must be a list or comma-separated string")
+
+    def setPartition(self, partition):
+        """Set the SLURM partition for remote execution.
+        
+        Args:
+            partition: SLURM partition name (e.g., 'standard', 'debug')
+        """
+        if partition:
+            self.__partition = str(partition)
 
     def __getRunRemote(self):
         try:
@@ -5052,6 +5062,7 @@ class RcsbDpUtility:
                 use_singularity=self.__use_singularity,
                 singularity_image=self.__singularity_image,
                 singularity_bind_paths=self.__singularity_bind_paths,
+                partition=self.__partition,
             ).run()
 
         if self.__timeout > 0:

--- a/wwpdb/utils/dp/RcsbDpUtility.py
+++ b/wwpdb/utils/dp/RcsbDpUtility.py
@@ -150,6 +150,7 @@ import glob
 import logging
 import math
 import os
+import re
 import random
 import shutil
 import signal
@@ -5046,6 +5047,29 @@ class RcsbDpUtility:
         logger.info("+RcsbDpUtility.__runTimeout() completed with return code %r\n", process.stdout.read())
         return 0
 
+    def __commandOnlyCallsPythonScripts(self, command):
+        """Check if all executables in the command are Python scripts.
+
+        Extracts absolute paths invoked after semicolons in the shell command
+        and reads their first line.  Returns True only if every resolved
+        executable is a Python script (shebang contains "python").
+        Returns False (use the container) if any executable is ELF,
+        a non-Python script, or cannot be read.
+        """
+        paths = re.findall(r";\s*(/\S+)", command)
+        executables = [p for p in paths if os.path.isfile(p)]
+        if not executables:
+            return False
+        for path in executables:
+            try:
+                with open(path, "rb") as f:
+                    head = f.read(256)
+                if not (head[:2] == b"#!" and b"python" in head.split(b"\n")[0]):
+                    return False
+            except (IOError, OSError):
+                return False
+        return True
+
     def __run(self, command, lPathFull, op):
         if self.__run_remote:
             random_suffix = random.randrange(9999999)  # noqa: S311
@@ -5059,7 +5083,7 @@ class RcsbDpUtility:
                 number_of_processors=self.__numThreads,
                 memory_limit=self.__startingMemory,
                 add_site_config=True,
-                use_singularity=self.__use_singularity,
+                use_singularity=self.__use_singularity and not self.__commandOnlyCallsPythonScripts(command),
                 singularity_image=self.__singularity_image,
                 singularity_bind_paths=self.__singularity_bind_paths,
                 partition=self.__partition,

--- a/wwpdb/utils/dp/RcsbDpUtility.py
+++ b/wwpdb/utils/dp/RcsbDpUtility.py
@@ -429,6 +429,9 @@ class RcsbDpUtility:
         self.__startingMemory = 2000  # this is used by RunRemote to set the starting RAM to be requested
 
         self.__run_remote = False
+        self.__use_singularity = False
+        self.__singularity_image = None
+        self.__singularity_bind_paths = []
 
         self.__cI = ConfigInfo(self.__siteId)
         self.__cICommon = ConfigInfoAppCommon(self.__siteId)
@@ -486,6 +489,30 @@ class RcsbDpUtility:
             self.__run_remote = True
         else:
             self.__run_remote = False
+
+    def setUseSingularity(self, use_singularity=True):
+        """Enable or disable Singularity container execution."""
+        self.__use_singularity = use_singularity
+
+    def setSingularityImage(self, image_path):
+        """Set the path to the Singularity image file."""
+        if image_path and os.path.exists(image_path):
+            self.__singularity_image = image_path
+        else:
+            logger.warning("Singularity image path does not exist: %s", image_path)
+
+    def setSingularityBindPaths(self, bind_paths):
+        """Set additional bind paths for Singularity container.
+        
+        Args:
+            bind_paths: List of bind paths or comma-separated string
+        """
+        if isinstance(bind_paths, list):
+            self.__singularity_bind_paths = bind_paths
+        elif isinstance(bind_paths, str):
+            self.__singularity_bind_paths = [p.strip() for p in bind_paths.split(",")]
+        else:
+            logger.error("bind_paths must be a list or comma-separated string")
 
     def __getRunRemote(self):
         try:
@@ -5003,6 +5030,9 @@ class RcsbDpUtility:
                 number_of_processors=self.__numThreads,
                 memory_limit=self.__startingMemory,
                 add_site_config=True,
+                use_singularity=self.__use_singularity,
+                singularity_image=self.__singularity_image,
+                singularity_bind_paths=self.__singularity_bind_paths,
             ).run()
 
         if self.__timeout > 0:

--- a/wwpdb/utils/dp/RcsbDpUtility.py
+++ b/wwpdb/utils/dp/RcsbDpUtility.py
@@ -439,6 +439,7 @@ class RcsbDpUtility:
         self.__cIVal = ConfigInfoAppValidation(self.__siteId)
         self.__initPath()
         self.__getRunRemote()
+        self.__getSingularity()
 
     def __getConfigPath(self, ky):
         try:
@@ -521,6 +522,24 @@ class RcsbDpUtility:
                     self.setRunRemote()
         except Exception as e:  # noqa: BLE001
             logger.info("unable to get cluster queue %s", str(e))
+
+    def __getSingularity(self):
+        """Check configuration and enable Singularity if configured."""
+        try:
+            if self.__cI.get("USE_SINGULARITY"):
+                self.setUseSingularity(True)
+                
+                # Get custom image path if configured
+                singularity_image = self.__cI.get("SINGULARITY_IMAGE")
+                if singularity_image:
+                    self.setSingularityImage(singularity_image)
+                
+                # Get custom bind paths if configured
+                bind_paths = self.__cI.get("SINGULARITY_BIND_PATHS")
+                if bind_paths:
+                    self.setSingularityBindPaths(bind_paths)
+        except Exception as e:  # noqa: BLE001
+            logger.info("unable to get singularity configuration %s", str(e))
 
     def setRcsbAppsPath(self, fPath):
         """Set or overwrite the configuration setting for __rcsbAppsPath."""

--- a/wwpdb/utils/dp/RcsbDpUtility.py
+++ b/wwpdb/utils/dp/RcsbDpUtility.py
@@ -150,7 +150,6 @@ import glob
 import logging
 import math
 import os
-import re
 import random
 import shutil
 import signal
@@ -5047,46 +5046,6 @@ class RcsbDpUtility:
         logger.info("+RcsbDpUtility.__runTimeout() completed with return code %r\n", process.stdout.read())
         return 0
 
-    def __commandOnlyCallsPythonScripts(self, command):
-        """Check if all executables in the command are Python scripts.
-
-        Inspects each token invoked after semicolons in the shell command.
-        For absolute paths, reads the first bytes to check for a Python shebang.
-        Also recognises bare ``python`` / ``python3`` invocations (e.g.
-        ``python -m wwpdb.apps.validation...``).
-
-        Returns True when every executable is Python-based, meaning the
-        command does not need a container for ELF/glibc compatibility.
-        Returns False (use the container) if any executable is ELF,
-        a non-Python script, or cannot be read.
-        """
-        # Match tokens invoked after semicolons — both absolute paths and bare commands
-        tokens = re.findall(r";\s*(\S+)", command)
-        # Filter to actionable commands: absolute paths to files, or bare python calls.
-        # Skip shell builtins/keywords (export, cd, cat, source, env, rm, mv, cp, touch, unset, .)
-        # and variable assignments (VAR=value).
-        skip = {"export", "cd", "cat", "source", ".", "env", "rm", "mv", "cp", "touch", "unset", "set"}
-        has_executables = False
-        for token in tokens:
-            if token in skip or "=" in token:
-                continue
-            if re.match(r"^python[23]?(\.\d+)?$", token):
-                has_executables = True
-                continue
-            if token.startswith("/") and os.path.isfile(token):
-                has_executables = True
-                try:
-                    with open(token, "rb") as f:
-                        head = f.read(256)
-                    if not (head[:2] == b"#!" and b"python" in head.split(b"\n")[0]):
-                        return False
-                except (IOError, OSError):
-                    return False
-            elif token.startswith("/"):
-                # Absolute path that doesn't exist — can't verify, assume not Python
-                return False
-        return has_executables
-
     def __run(self, command, lPathFull, op):
         if self.__run_remote:
             random_suffix = random.randrange(9999999)  # noqa: S311
@@ -5100,7 +5059,7 @@ class RcsbDpUtility:
                 number_of_processors=self.__numThreads,
                 memory_limit=self.__startingMemory,
                 add_site_config=True,
-                use_singularity=self.__use_singularity and not self.__commandOnlyCallsPythonScripts(command),
+                use_singularity=self.__use_singularity,
                 singularity_image=self.__singularity_image,
                 singularity_bind_paths=self.__singularity_bind_paths,
                 partition=self.__partition,

--- a/wwpdb/utils/dp/RcsbDpUtility.py
+++ b/wwpdb/utils/dp/RcsbDpUtility.py
@@ -5050,25 +5050,42 @@ class RcsbDpUtility:
     def __commandOnlyCallsPythonScripts(self, command):
         """Check if all executables in the command are Python scripts.
 
-        Extracts absolute paths invoked after semicolons in the shell command
-        and reads their first line.  Returns True only if every resolved
-        executable is a Python script (shebang contains "python").
+        Inspects each token invoked after semicolons in the shell command.
+        For absolute paths, reads the first bytes to check for a Python shebang.
+        Also recognises bare ``python`` / ``python3`` invocations (e.g.
+        ``python -m wwpdb.apps.validation...``).
+
+        Returns True when every executable is Python-based, meaning the
+        command does not need a container for ELF/glibc compatibility.
         Returns False (use the container) if any executable is ELF,
         a non-Python script, or cannot be read.
         """
-        paths = re.findall(r";\s*(/\S+)", command)
-        executables = [p for p in paths if os.path.isfile(p)]
-        if not executables:
-            return False
-        for path in executables:
-            try:
-                with open(path, "rb") as f:
-                    head = f.read(256)
-                if not (head[:2] == b"#!" and b"python" in head.split(b"\n")[0]):
+        # Match tokens invoked after semicolons — both absolute paths and bare commands
+        tokens = re.findall(r";\s*(\S+)", command)
+        # Filter to actionable commands: absolute paths to files, or bare python calls.
+        # Skip shell builtins/keywords (export, cd, cat, source, env, rm, mv, cp, touch, unset, .)
+        # and variable assignments (VAR=value).
+        skip = {"export", "cd", "cat", "source", ".", "env", "rm", "mv", "cp", "touch", "unset", "set"}
+        has_executables = False
+        for token in tokens:
+            if token in skip or "=" in token:
+                continue
+            if re.match(r"^python[23]?(\.\d+)?$", token):
+                has_executables = True
+                continue
+            if token.startswith("/") and os.path.isfile(token):
+                has_executables = True
+                try:
+                    with open(token, "rb") as f:
+                        head = f.read(256)
+                    if not (head[:2] == b"#!" and b"python" in head.split(b"\n")[0]):
+                        return False
+                except (IOError, OSError):
                     return False
-            except (IOError, OSError):
+            elif token.startswith("/"):
+                # Absolute path that doesn't exist — can't verify, assume not Python
                 return False
-        return True
+        return has_executables
 
     def __run(self, command, lPathFull, op):
         if self.__run_remote:

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -7,7 +7,6 @@ import subprocess
 import tempfile
 import time
 from enum import Enum
-from textwrap import dedent
 
 from wwpdb.utils.config.ConfigInfo import ConfigInfo, getSiteId
 
@@ -148,13 +147,12 @@ class RunRemote:
         logger.debug(f"Command to execute: {command}")
         
         with open(self._shell_script, "w") as f:
-            cmd = f"""\
-            #!/bin/bash
-            set -e
-            export XDG_RUNTIME_DIR={self.run_dir}
-            {command}
-            """
-            f.write(dedent(cmd))
+            cmd = f"""#!/bin/bash
+set -e
+export XDG_RUNTIME_DIR={self.run_dir}
+{command}
+"""
+            f.write(cmd)
             f.flush()
         os.chmod(self._shell_script, 0o775)
 

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -144,6 +144,8 @@ class RunRemote:
             "--error=%s" % self._stderr_file,
         ]
 
+        logger.debug(f"Command to execute: {command}")
+        
         with open(self._shell_script, "w") as f:
             cmd = f"""\
             #!/bin/bash

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -59,7 +59,7 @@ class RunRemote:
         self.add_site_config = add_site_config
         self.add_site_config_database = add_site_config_database
         self.use_singularity = use_singularity
-        self.singularity_image = singularity_image or "/nfs/public/services/onedep_gpfs/docker-tools/onedep-builder_rocky8.sif"
+        self.singularity_image = singularity_image
         self.singularity_bind_paths = singularity_bind_paths or []
 
         if not self.run_dir:

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -142,6 +142,7 @@ class RunRemote:
             "--chdir=%s" % self.run_dir,
             "--output=%s" % self._stdout_file,
             "--error=%s" % self._stderr_file,
+            "--export=ALL",  # Inherit environment variables for nested container detection
         ]
 
         logger.debug(f"Command to execute: {command}")

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -174,41 +174,35 @@ export XDG_RUNTIME_DIR={self.run_dir}
             logger.info("Already inside Singularity container, skipping container wrapping")
             return command
         
-        # Get onedep root, fallback to common paths if not configured
+        # Get onedep root from config only
         top_config_dir = self.cI.get("TOP_WWPDB_SITE_CONFIG_DIR")
-        if top_config_dir:
-            onedep_root = top_config_dir.rstrip("/site-config")
-        else:
-            # Fallback: try to determine from environment or use current directory
-            onedep_root = os.environ.get("ONEDEP_PATH", "/opt/wwpdb")
-            logger.warning(f"TOP_WWPDB_SITE_CONFIG_DIR not configured, using fallback: {onedep_root}")
-        
+        onedep_root = top_config_dir.rstrip("/site-config") if top_config_dir else None
+
         # Build bind mount arguments
         bind_mounts = [
             "--bind /tmp:/tmp",
             f"--bind {self.log_dir}:{self.log_dir}",
             f"--bind {self.run_dir}:{self.run_dir}",
         ]
-        
+
         # Add onedep root only if it exists and is absolute
         if onedep_root and os.path.isabs(onedep_root):
             bind_mounts.insert(0, f"--bind {onedep_root}:{onedep_root}")
-        
+
         # Add custom bind paths
         for bind_path in self.singularity_bind_paths:
             bind_mounts.append(f"--bind {bind_path}")
-        
+
         bind_args = " ".join(bind_mounts)
-        
+
         # Build environment variables
         site_loc = self.cI.get('WWPDB_SITE_LOC') or 'UNKNOWN'
         env_vars = [
             f"--env WWPDB_SITE_ID={self.siteId}",
             f"--env WWPDB_SITE_LOC={site_loc}",
-            f"--env ONEDEP_PATH={onedep_root}",
         ]
         env_args = " ".join(env_vars)
-        
+
         singularity_cmd = (
             f"singularity exec --cleanenv "
             f"{bind_args} "
@@ -216,7 +210,7 @@ export XDG_RUNTIME_DIR={self.run_dir}
             f"{self.singularity_image} "
             f"bash -c '{command}'"
         )
-        
+
         return singularity_cmd
 
     def _source_site_config(self, database=False):

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -157,7 +157,16 @@ class RunRemote:
             shutil.rmtree(self.run_dir)
 
     def _wrap_with_singularity(self, command):
-        """Wrap a command to execute inside the Singularity container."""
+        """Wrap a command to execute inside the Singularity container.
+        
+        Detects if already running inside a Singularity container and skips
+        wrapping to avoid nested containerization.
+        """
+        # Check if we're already inside a Singularity container
+        if os.environ.get("SINGULARITY_CONTAINER") or os.environ.get("SINGULARITY_NAME"):
+            logger.info("Already inside Singularity container, skipping container wrapping")
+            return command
+        
         onedep_root = self.cI.get("TOP_WWPDB_SITE_CONFIG_DIR").rstrip("/site-config")
         
         # Build bind mount arguments

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -48,6 +48,7 @@ class RunRemote:
         use_singularity=False,
         singularity_image=None,
         singularity_bind_paths=None,
+        partition=None,
     ):
         self.command = command
         self.job_name = job_name
@@ -68,7 +69,12 @@ class RunRemote:
 
         self.siteId = getSiteId()
         self.cI = ConfigInfo(self.siteId)
-        self.pdbe_cluster_queue = str(self.cI.get("PDBE_CLUSTER_QUEUE"))
+        # Use provided partition, or fall back to config, or use "standard" as default
+        if partition:
+            self.pdbe_cluster_queue = str(partition)
+        else:
+            config_partition = self.cI.get("PDBE_CLUSTER_QUEUE")
+            self.pdbe_cluster_queue = str(config_partition) if config_partition else "standard"
         self._stdout_file = os.path.join(self.log_dir, self.job_name + ".out")
         self._stderr_file = os.path.join(self.log_dir, self.job_name + ".err")
 

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -200,6 +200,7 @@ export XDG_RUNTIME_DIR={self.run_dir}
         env_vars = [
             f"--env WWPDB_SITE_ID={self.siteId}",
             f"--env WWPDB_SITE_LOC={site_loc}",
+            "--env PYTHON=/usr/bin/python3",
         ]
         env_args = " ".join(env_vars)
 

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -200,7 +200,6 @@ export XDG_RUNTIME_DIR={self.run_dir}
         env_vars = [
             f"--env WWPDB_SITE_ID={self.siteId}",
             f"--env WWPDB_SITE_LOC={site_loc}",
-            "--env PYTHON=/usr/bin/python3",
         ]
         env_args = " ".join(env_vars)
 


### PR DESCRIPTION
This pull request adds support for running remote jobs inside a Singularity container in the `RcsbDpUtility` and `RunRemote` modules. It introduces configuration options and logic to enable or disable containerization, specify images and bind paths, and avoid unnecessary container usage for pure Python jobs. The main changes can be grouped as follows:

**Singularity container integration:**

* Added Singularity-related configuration and state variables (`__use_singularity`, `__singularity_image`, `__singularity_bind_paths`, `__partition`) to `RcsbDpUtility` and initialized them from config files. Provided setters for these options. (`[[1]](diffhunk://#diff-2e2869b065e067698eb47b67f09dfb23c80c48f00226941f5dea3c8587cb6e7dR433-R444)`, `[[2]](diffhunk://#diff-2e2869b065e067698eb47b67f09dfb23c80c48f00226941f5dea3c8587cb6e7dR496-R528)`, `[[3]](diffhunk://#diff-2e2869b065e067698eb47b67f09dfb23c80c48f00226941f5dea3c8587cb6e7dR537-R554)`)
* Updated `__run` in `RcsbDpUtility` to pass Singularity options to `RunRemote`, and added logic to only use Singularity if the command is not purely Python-based. (`[[1]](diffhunk://#diff-2e2869b065e067698eb47b67f09dfb23c80c48f00226941f5dea3c8587cb6e7dR5050-R5089)`, `[[2]](diffhunk://#diff-2e2869b065e067698eb47b67f09dfb23c80c48f00226941f5dea3c8587cb6e7dR5103-R5106)`)
* In `RunRemote`, added parameters and logic to wrap commands using Singularity, including detection of nested containers and construction of bind mounts and environment variables. (`[[1]](diffhunk://#diff-0bec41aa508ed1c2af5339f02d9075f7c749d732fee45898b42a3b13e832edd0R47-R50)`, `[[2]](diffhunk://#diff-0bec41aa508ed1c2af5339f02d9075f7c749d732fee45898b42a3b13e832edd0R61-R76)`, `[[3]](diffhunk://#diff-0bec41aa508ed1c2af5339f02d9075f7c749d732fee45898b42a3b13e832edd0R166-R216)`, `[[4]](diffhunk://#diff-0bec41aa508ed1c2af5339f02d9075f7c749d732fee45898b42a3b13e832edd0R235-R238)`)

**Partition and SLURM integration:**

* Added support for specifying the SLURM partition (queue) for job submission, either via parameter or configuration, defaulting to "standard" if not set. (`F75435fbL45R44`, `[wwpdb/utils/dp/RunRemote.pyR61-R76](diffhunk://#diff-0bec41aa508ed1c2af5339f02d9075f7c749d732fee45898b42a3b13e832edd0R61-R76)`)

**Python job detection:**

* Implemented `__commandOnlyCallsPythonScripts` in `RcsbDpUtility` to detect if a command only runs Python scripts, allowing the system to skip containerization for such jobs. (`[wwpdb/utils/dp/RcsbDpUtility.pyR5050-R5089](diffhunk://#diff-2e2869b065e067698eb47b67f09dfb23c80c48f00226941f5dea3c8587cb6e7dR5050-R5089)`)

**Command-line interface enhancements:**

* Extended the `RunRemote` CLI with options for Singularity usage, image selection, and bind paths. (`[[1]](diffhunk://#diff-0bec41aa508ed1c2af5339f02d9075f7c749d732fee45898b42a3b13e832edd0R276-R287)`, `[[2]](diffhunk://#diff-0bec41aa508ed1c2af5339f02d9075f7c749d732fee45898b42a3b13e832edd0R297-R299)`)

**Other improvements:**

* Added `re` import for regex matching in Python job detection. (`[wwpdb/utils/dp/RcsbDpUtility.pyR153](diffhunk://#diff-2e2869b065e067698eb47b67f09dfb23c80c48f00226941f5dea3c8587cb6e7dR153)`)
* Ensured environment variables are exported in SLURM jobs for correct container detection. (`[wwpdb/utils/dp/RunRemote.pyR144-R155](diffhunk://#diff-0bec41aa508ed1c2af5339f02d9075f7c749d732fee45898b42a3b13e832edd0R144-R155)`)

These changes enable flexible and configurable use of Singularity containers for remote job execution, improving compatibility and reproducibility for heterogeneous compute environments.