### PR TITLE
Fix OOM classification and enhance retry-safe rundir handling

### DIFF
--- a/tests/RunRemoteTests.py
+++ b/tests/RunRemoteTests.py
@@ -1,0 +1,231 @@
+"""Hermetic unit tests for wwpdb.utils.dp.RunRemote job-status classification.
+
+These mock subprocess and site-config calls, unlike RcsbDpUtilityRunRemoteTests.py, which is a
+real-tool integration suite that submits actual Slurm jobs. Scope: get_job_status_by_id()'s
+squeue/sacct fallback, _get_job_status_from_sacct()'s accounting-lag backoff, and monitor()'s
+terminal-state handling.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+if __package__ is None or __package__ == "":
+    from os import path
+
+    sys.path.append(path.dirname(path.abspath(__file__)))
+
+from wwpdb.utils.dp.RunRemote import JobStatus, RunRemote
+
+
+def _make_run_remote(command="echo hi", run_dir=None):
+    """Construct a real RunRemote instance without needing a live site-config environment.
+
+    run_dir defaults to None (RunRemote auto-generates a /tmp/run_remote_* tempdir, matching
+    RunRemote's own default), but retry-loop tests that call _cleanup() more than once should
+    pass an explicit non-"/tmp/run_remote_"-prefixed run_dir, matching how RcsbDpUtility always
+    supplies an explicit workflow-instance run_dir for the ValMod path in production -- _cleanup()
+    is a no-op for those, same as it is live.
+    """
+    with mock.patch("wwpdb.utils.dp.RunRemote.getSiteId", return_value="WWPDB_DEPLOY_TEST"), mock.patch(
+        "wwpdb.utils.dp.RunRemote.ConfigInfo"
+    ) as mock_config_info:
+        mock_config_info.return_value.get.return_value = "test_queue"
+        return RunRemote(command=command, job_name="test_job", log_dir=tempfile.mkdtemp(), run_dir=run_dir)
+
+
+def _sacct_json(job_id=12345, state=None):
+    jobs = [{"job_id": job_id, "state": {"current": state}}] if state is not None else []
+    return json.dumps({"jobs": jobs})
+
+
+def _fake_subprocess_run(fake_squeue=None, fake_sacct_sequence=None):
+    """Build a subprocess.run side_effect that dispatches on the command name.
+
+    fake_squeue: (returncode, stdout_text) for the squeue call.
+    fake_sacct_sequence: list of (returncode, stdout_text) consumed one per sacct call, in order.
+    """
+    sacct_iter = iter(fake_sacct_sequence or [])
+
+    def _run(cmd, **_kwargs):
+        if cmd[0] == "squeue":
+            rc, stdout_text = fake_squeue
+            return mock.Mock(returncode=rc, stdout=stdout_text.encode("utf-8"))
+        if cmd[0] == "sacct":
+            try:
+                rc, stdout_text = next(sacct_iter)
+            except StopIteration as exc:
+                raise AssertionError("sacct called more times than fake_sacct_sequence provides") from exc
+            if rc != 0:
+                raise subprocess.CalledProcessError(rc, cmd)
+            return mock.Mock(returncode=rc, stdout=stdout_text)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    return _run
+
+
+class GetJobStatusByIdTests(unittest.TestCase):
+    def setUp(self):
+        self.run_remote = _make_run_remote()
+
+    def test_squeue_classifies_directly_unchanged_behavior(self):
+        """Regression guard: when squeue succeeds, its answer is used as-is, no sacct call."""
+        fake_run = _fake_subprocess_run(fake_squeue=(0, "COMPLETED"))
+        with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run) as mock_run:
+            status = self.run_remote.get_job_status_by_id(12345)
+        self.assertEqual(status, JobStatus.COMPLETED)
+        self.assertEqual(mock_run.call_count, 1)  # only squeue, no sacct fallback
+
+    def test_squeue_reports_oom_directly(self):
+        fake_run = _fake_subprocess_run(fake_squeue=(0, "OUT_OF_MEMORY"))
+        with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run):
+            status = self.run_remote.get_job_status_by_id(12345)
+        self.assertEqual(status, JobStatus.OOM)
+
+    def test_squeue_forgets_job_falls_back_to_sacct_oom(self):
+        """The diagnosed bug: squeue rc=1 for a reaped job; sacct still has OUT_OF_MEMORY."""
+        fake_run = _fake_subprocess_run(
+            fake_squeue=(1, "slurm_load_jobs error: Invalid job id specified"),
+            fake_sacct_sequence=[(0, _sacct_json(state=["OUT_OF_MEMORY"]))],
+        )
+        with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run):
+            status = self.run_remote.get_job_status_by_id(12345)
+        self.assertEqual(status, JobStatus.OOM)
+
+    def test_squeue_blank_output_falls_back_to_sacct(self):
+        fake_run = _fake_subprocess_run(
+            fake_squeue=(0, ""),
+            fake_sacct_sequence=[(0, _sacct_json(state=["COMPLETED"]))],
+        )
+        with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run):
+            status = self.run_remote.get_job_status_by_id(12345)
+        self.assertEqual(status, JobStatus.COMPLETED)
+
+    def test_squeue_and_sacct_both_fail_to_classify_returns_other(self):
+        """Never fabricate a terminal state -- fall back to OTHER, not a false positive."""
+        fake_run = _fake_subprocess_run(
+            fake_squeue=(1, "slurm_load_jobs error: Invalid job id specified"),
+            fake_sacct_sequence=[(0, _sacct_json(state=None))] * 3,  # empty jobs list every attempt
+        )
+        with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run), mock.patch(
+            "wwpdb.utils.dp.RunRemote.time.sleep"
+        ):
+            status = self.run_remote.get_job_status_by_id(12345)
+        self.assertEqual(status, JobStatus.OTHER)
+
+
+class GetJobStatusFromSacctTests(unittest.TestCase):
+    def setUp(self):
+        self.run_remote = _make_run_remote()
+
+    def test_backoff_on_empty_then_populated(self):
+        """sacct accounting lag: empty jobs list on first attempt, populated on the second."""
+        fake_run = _fake_subprocess_run(
+            fake_sacct_sequence=[
+                (0, _sacct_json(state=None)),
+                (0, _sacct_json(state=["COMPLETED"])),
+            ]
+        )
+        with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run) as mock_run, mock.patch(
+            "wwpdb.utils.dp.RunRemote.time.sleep"
+        ) as mock_sleep:
+            status = self.run_remote._get_job_status_from_sacct(12345)  # noqa: SLF001
+        self.assertEqual(status, JobStatus.COMPLETED)
+        self.assertEqual(mock_run.call_count, 2)
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    def test_never_classifies_after_max_attempts_returns_none(self):
+        fake_run = _fake_subprocess_run(fake_sacct_sequence=[(0, _sacct_json(state=None))] * 3)
+        with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run), mock.patch(
+            "wwpdb.utils.dp.RunRemote.time.sleep"
+        ):
+            status = self.run_remote._get_job_status_from_sacct(12345, max_attempts=3, backoff=0)  # noqa: SLF001
+        self.assertIsNone(status)
+
+
+class MonitorTests(unittest.TestCase):
+    def setUp(self):
+        self.run_remote = _make_run_remote()
+
+    def test_returns_terminal_status_without_extra_query_after_break(self):
+        """Regression guard for the redundant re-query bug: monitor() must not call
+        get_job_status_by_id() again after it already has a terminal status."""
+        with mock.patch.object(
+            self.run_remote, "get_job_status_by_id", side_effect=[JobStatus.RUNNING, JobStatus.RUNNING, JobStatus.COMPLETED]
+        ) as mock_status, mock.patch("wwpdb.utils.dp.RunRemote.time.sleep"):
+            status = self.run_remote.monitor(12345, frequency=0)
+        self.assertEqual(status, JobStatus.COMPLETED)
+        self.assertEqual(mock_status.call_count, 3)  # exactly the 3 polls, no extra call after break
+
+    def test_returns_oom_status_without_extra_query_after_break(self):
+        with mock.patch.object(self.run_remote, "get_job_status_by_id", side_effect=[JobStatus.RUNNING, JobStatus.OOM]) as mock_status:
+            status = self.run_remote.monitor(12345, frequency=0)
+        self.assertEqual(status, JobStatus.OOM)
+        self.assertEqual(mock_status.call_count, 2)
+
+
+class RedirectRundirForRetryTests(unittest.TestCase):
+    def setUp(self):
+        self.run_remote = _make_run_remote()
+
+    def test_redirects_rundir_with_attempt_suffix(self):
+        command = "python -m wwpdb.apps.validation.src.validator --mode annotate --rundir /nfs/data/sessions/validation_123 --kind foo"
+        redirected = self.run_remote._redirect_rundir_for_retry(command, 1)  # noqa: SLF001
+        self.assertIn("--rundir /nfs/data/sessions/validation_123_retry1", redirected)
+        self.assertNotIn("--rundir /nfs/data/sessions/validation_123 ", redirected)
+
+    def test_different_attempt_numbers_produce_different_suffixes(self):
+        command = "cmd --rundir /nfs/data/sessions/validation_123"
+        self.assertIn("_retry1", self.run_remote._redirect_rundir_for_retry(command, 1))  # noqa: SLF001
+        self.assertIn("_retry2", self.run_remote._redirect_rundir_for_retry(command, 2))  # noqa: SLF001
+
+    def test_only_the_rundir_token_changes(self):
+        command = "cmd --before flag --rundir /nfs/data/sessions/validation_123 --after flag"
+        redirected = self.run_remote._redirect_rundir_for_retry(command, 3)  # noqa: SLF001
+        self.assertEqual(redirected, "cmd --before flag --rundir /nfs/data/sessions/validation_123_retry3 --after flag")
+
+    def test_command_without_rundir_is_unchanged(self):
+        """The majority of RunRemote-dispatched jobs (e.g. chem-comp-link, sf-convert) have no --rundir."""
+        command = "python -m some.other.tool --input foo.cif --output bar.cif"
+        self.assertEqual(self.run_remote._redirect_rundir_for_retry(command, 1), command)  # noqa: SLF001
+
+
+class RunRetryRedirectsRundirTests(unittest.TestCase):
+    def setUp(self):
+        # A non-"/tmp/run_remote_"-prefixed run_dir, matching production's ValMod path, so
+        # _cleanup() (called once per attempt) is a safe no-op across multiple retries.
+        self.run_dir = tempfile.mkdtemp(prefix="workflow_instance_")
+        self.run_remote = _make_run_remote(
+            command="python -m wwpdb.apps.validation.src.validator --rundir /nfs/data/sessions/validation_999",
+            run_dir=self.run_dir,
+        )
+
+    def test_second_attempt_uses_redirected_rundir(self):
+        submitted_job_ids = iter([111, 222])
+
+        def fake_sbatch_run(cmd, **_kwargs):
+            return mock.Mock(returncode=0, stdout=f"Submitted batch job {next(submitted_job_ids)}\n".encode("utf-8"))
+
+        with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_sbatch_run), mock.patch.object(
+            self.run_remote, "_build_sbatch_command", wraps=self.run_remote._build_sbatch_command
+        ) as mock_build, mock.patch.object(
+            self.run_remote, "monitor", side_effect=[JobStatus.OOM, JobStatus.COMPLETED]
+        ), mock.patch.object(
+            self.run_remote, "_get_job_metrics", return_value={}
+        ):
+            result = self.run_remote.run(retries=3)
+
+        self.assertEqual(result.status, JobStatus.COMPLETED)
+        self.assertEqual(mock_build.call_count, 2)
+        first_attempt_command = mock_build.call_args_list[0].kwargs["command"]
+        second_attempt_command = mock_build.call_args_list[1].kwargs["command"]
+        self.assertIn("--rundir /nfs/data/sessions/validation_999", first_attempt_command)
+        self.assertNotIn("_retry", first_attempt_command)
+        self.assertIn("--rundir /nfs/data/sessions/validation_999_retry1", second_attempt_command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/RunRemoteTests.py
+++ b/tests/RunRemoteTests.py
@@ -132,7 +132,7 @@ class GetJobStatusFromSacctTests(unittest.TestCase):
         with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run) as mock_run, mock.patch(
             "wwpdb.utils.dp.RunRemote.time.sleep"
         ) as mock_sleep:
-            status = self.run_remote._get_job_status_from_sacct(12345)  # noqa: SLF001
+            status = self.run_remote._get_job_status_from_sacct(12345)  # pylint: disable=protected-access
         self.assertEqual(status, JobStatus.COMPLETED)
         self.assertEqual(mock_run.call_count, 2)
         self.assertEqual(mock_sleep.call_count, 1)
@@ -142,7 +142,7 @@ class GetJobStatusFromSacctTests(unittest.TestCase):
         with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_run), mock.patch(
             "wwpdb.utils.dp.RunRemote.time.sleep"
         ):
-            status = self.run_remote._get_job_status_from_sacct(12345, max_attempts=3, backoff=0)  # noqa: SLF001
+            status = self.run_remote._get_job_status_from_sacct(12345, max_attempts=3, backoff=0)  # pylint: disable=protected-access
         self.assertIsNone(status)
 
 
@@ -173,24 +173,24 @@ class RedirectRundirForRetryTests(unittest.TestCase):
 
     def test_redirects_rundir_with_attempt_suffix(self):
         command = "python -m wwpdb.apps.validation.src.validator --mode annotate --rundir /nfs/data/sessions/validation_123 --kind foo"
-        redirected = self.run_remote._redirect_rundir_for_retry(command, 1)  # noqa: SLF001
+        redirected = self.run_remote._redirect_rundir_for_retry(command, 1)  # pylint: disable=protected-access
         self.assertIn("--rundir /nfs/data/sessions/validation_123_retry1", redirected)
         self.assertNotIn("--rundir /nfs/data/sessions/validation_123 ", redirected)
 
     def test_different_attempt_numbers_produce_different_suffixes(self):
         command = "cmd --rundir /nfs/data/sessions/validation_123"
-        self.assertIn("_retry1", self.run_remote._redirect_rundir_for_retry(command, 1))  # noqa: SLF001
-        self.assertIn("_retry2", self.run_remote._redirect_rundir_for_retry(command, 2))  # noqa: SLF001
+        self.assertIn("_retry1", self.run_remote._redirect_rundir_for_retry(command, 1))  # pylint: disable=protected-access
+        self.assertIn("_retry2", self.run_remote._redirect_rundir_for_retry(command, 2))  # pylint: disable=protected-access
 
     def test_only_the_rundir_token_changes(self):
         command = "cmd --before flag --rundir /nfs/data/sessions/validation_123 --after flag"
-        redirected = self.run_remote._redirect_rundir_for_retry(command, 3)  # noqa: SLF001
+        redirected = self.run_remote._redirect_rundir_for_retry(command, 3)  # pylint: disable=protected-access
         self.assertEqual(redirected, "cmd --before flag --rundir /nfs/data/sessions/validation_123_retry3 --after flag")
 
     def test_command_without_rundir_is_unchanged(self):
         """The majority of RunRemote-dispatched jobs (e.g. chem-comp-link, sf-convert) have no --rundir."""
         command = "python -m some.other.tool --input foo.cif --output bar.cif"
-        self.assertEqual(self.run_remote._redirect_rundir_for_retry(command, 1), command)  # noqa: SLF001
+        self.assertEqual(self.run_remote._redirect_rundir_for_retry(command, 1), command)  # pylint: disable=protected-access
 
 
 class RunRetryRedirectsRundirTests(unittest.TestCase):
@@ -206,11 +206,11 @@ class RunRetryRedirectsRundirTests(unittest.TestCase):
     def test_second_attempt_uses_redirected_rundir(self):
         submitted_job_ids = iter([111, 222])
 
-        def fake_sbatch_run(cmd, **_kwargs):
+        def fake_sbatch_run(_cmd, **_kwargs):
             return mock.Mock(returncode=0, stdout=f"Submitted batch job {next(submitted_job_ids)}\n".encode("utf-8"))
 
         with mock.patch("wwpdb.utils.dp.RunRemote.subprocess.run", side_effect=fake_sbatch_run), mock.patch.object(
-            self.run_remote, "_build_sbatch_command", wraps=self.run_remote._build_sbatch_command
+            self.run_remote, "_build_sbatch_command", wraps=self.run_remote._build_sbatch_command  # pylint: disable=protected-access
         ) as mock_build, mock.patch.object(
             self.run_remote, "monitor", side_effect=[JobStatus.OOM, JobStatus.COMPLETED]
         ), mock.patch.object(

--- a/wwpdb/utils/dp/RunRemote.py
+++ b/wwpdb/utils/dp/RunRemote.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -99,21 +100,9 @@ class RunRemote:
         self._stdout_file = os.path.join(self.log_dir, self.job_name + ".out")
         self._stderr_file = os.path.join(self.log_dir, self.job_name + ".err")
 
-    def get_job_status_by_id(self, job_id) -> JobStatus:
-        """Get the status of a single job by ID."""
-        cmd = [
-            "squeue",
-            "--noheader",
-            "-t",
-            "all",
-            "--Format",
-            "State",
-            "--jobs",
-            str(job_id),
-        ]
-        squeue_output = subprocess.run(cmd, check=True, capture_output=True)
-        status_text = squeue_output.stdout.decode("utf-8").strip()
-
+    @staticmethod
+    def _map_status_text(status_text) -> JobStatus:
+        """Map a Slurm state string (from squeue or sacct) to a JobStatus."""
         if status_text in ["FAILED", "TIMEOUT"]:
             return JobStatus.FAILED
         if status_text == "OUT_OF_MEMORY":
@@ -125,6 +114,69 @@ class RunRemote:
         if status_text == "CANCELLED":
             return JobStatus.CANCELLED
         return JobStatus.OTHER
+
+    def get_job_status_by_id(self, job_id) -> JobStatus:
+        """Get the status of a single job by ID.
+
+        squeue is the fast path, but squeue stops reporting a job shortly after it finishes --
+        returning a non-zero return code or blank output -- even though the job actually
+        completed (e.g. hit OUT_OF_MEMORY). sacct retains the accounting record after squeue
+        has forgotten it, so fall back to sacct only when squeue itself fails to produce a
+        usable answer; when squeue does answer, that answer is preserved unchanged.
+        """
+        cmd = [
+            "squeue",
+            "--noheader",
+            "-t",
+            "all",
+            "--Format",
+            "State",
+            "--jobs",
+            str(job_id),
+        ]
+        squeue_output = subprocess.run(cmd, check=False, capture_output=True)
+        status_text = squeue_output.stdout.decode("utf-8").strip()
+
+        if squeue_output.returncode == 0 and status_text:
+            return self._map_status_text(status_text)
+
+        logger.debug(f"squeue could not classify job {job_id} (rc={squeue_output.returncode}, output={status_text!r}); falling back to sacct")
+        sacct_status = self._get_job_status_from_sacct(job_id)
+        return sacct_status if sacct_status is not None else JobStatus.OTHER
+
+    def _get_job_status_from_sacct(self, job_id, max_attempts=3, backoff=2):
+        """Classify a job's terminal status via sacct, tolerating brief accounting lag.
+
+        Right after a job finishes, sacct can briefly have no record yet -- retry a few times
+        with backoff before giving up rather than treating a momentary gap as classification
+        failure.
+        """
+        for attempt in range(1, max_attempts + 1):
+            try:
+                cmd = ["sacct", "--json", "--jobs", str(job_id)]
+                output = subprocess.run(cmd, check=True, capture_output=True, text=True)
+                data = json.loads(output.stdout)
+            except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+                logger.warning(f"Error querying sacct for job {job_id} status (attempt {attempt}/{max_attempts}): {e}")
+                time.sleep(backoff)
+                continue
+
+            jobs = data.get("jobs")
+            if not jobs:
+                logger.debug(f"sacct has no record yet for job {job_id} (attempt {attempt}/{max_attempts})")
+                time.sleep(backoff)
+                continue
+
+            state_list = jobs[0].get("state", {}).get("current", [])
+            if not state_list:
+                logger.warning(f"sacct record for job {job_id} has no state.current: {jobs[0]}")
+                time.sleep(backoff)
+                continue
+
+            return self._map_status_text(state_list[0])
+
+        logger.warning(f"sacct did not classify job {job_id} after {max_attempts} attempts")
+        return None
 
     def requeue_job(self, job_id):
         """Requeue a single job."""
@@ -222,16 +274,13 @@ class RunRemote:
 
             if status in (JobStatus.CANCELLED, JobStatus.FAILED, JobStatus.OOM):
                 logger.warning(f"Job {job_id} failed with status {status}")
-                break
+                return status
             if status == JobStatus.COMPLETED:
                 logger.info(f"Job {job_id} completed successfully")
-                break
-            else:
-                logger.debug(f"Job {job_id} status: {status}")
+                return status
 
+            logger.debug(f"Job {job_id} status: {status}")
             time.sleep(frequency)
-
-        return self.get_job_status_by_id(job_id)
 
     def _build_sbatch_command(self, command):
         sbatch_args = [
@@ -275,6 +324,27 @@ class RunRemote:
 
         return "{}; {}".format(site_config_command, self.command)
 
+    _RUNDIR_PATTERN = re.compile(r"--rundir (\S+)")
+
+    def _redirect_rundir_for_retry(self, command, attempt):
+        """Point a retried command's --rundir at a fresh, never-used sibling directory.
+
+        Some commands (the wwPDB validator's run_multithread(), see py-wwpdb_apps_validation
+        wwpdb/apps/validation/src/run_validator/runvalidation.py) are not safe to rerun
+        against a --rundir a previous attempt already used: they create per-run working
+        subdirectories with a bare os.mkdir() (no exist_ok), which raises FileExistsError if
+        a prior attempt already created them -- even if that prior attempt did real, useful
+        work before being killed (e.g. by OOM). Redirecting each retry to an unused sibling
+        directory avoids the collision entirely without needing to fix the callee. Commands
+        with no --rundir (the majority of RunRemote-dispatched jobs) are returned unchanged.
+        """
+        match = self._RUNDIR_PATTERN.search(command)
+        if not match:
+            return command
+        original_rundir = match.group(1)
+        retry_rundir = f"{original_rundir}_retry{attempt}"
+        return command[: match.start()] + f"--rundir {retry_rundir}" + command[match.end() :]
+
     def run(self, retries=3) -> JobResult:
         status = JobStatus.OTHER
         job_id = None
@@ -305,6 +375,7 @@ class RunRemote:
                 logger.info(f"Retrying job {job_id} with memory limit {self.memory_limit}")
                 retries -= 1
                 retries_used += 1
+                wf_command = self._redirect_rundir_for_retry(wf_command, retries_used)
             except subprocess.CalledProcessError as e:
                 logger.error(f"Error submitting job: {e}")
                 break


### PR DESCRIPTION
Fix OOM classification and make retries use unique rundirs

Summary
- When squeue cannot classify a finished job (non-zero return code or blank output), fall back to sacct with retries/backoff so terminal states like OUT_OF_MEMORY are preserved.
- Return terminal statuses immediately from monitor() to avoid redundant re-queries.
- For retried submissions, rewrite "--rundir <path>" → "--rundir <path>_retryN" so each retry writes to a fresh directory and avoids filesystem collisions.
- Adds hermetic unit tests that cover squeue/sacct paths, sacct backoff, monitor behavior, rundir redirection, and retry integration.

Problem
- squeue can stop reporting a job shortly after it finishes; without a sacct fallback this can lose terminal classifications (e.g. OOM → OTHER).
- Some downstream tools are not safe to re-run against the same --rundir (they create subdirectories without exist_ok), so retries can fail with FileExistsError even though retrying is desired.

What this PR changes
- get_job_status_by_id:
  - Use squeue output when rc==0 and non-empty.
  - If squeue can’t classify, call _get_job_status_from_sacct(job_id) which retries sacct --json with backoff, parses state.current, and maps to JobStatus.
- New helper _map_status_text(status_text) to centralize mapping from Slurm state strings to JobStatus.
- monitor(job_id): return immediately on terminal statuses (COMPLETED, CANCELLED, FAILED, OOM).
- _redirect_rundir_for_retry(command, attempt): regex-based rewrite of --rundir to add a _retryN suffix; integrated into run() so retried submissions use distinct rundirs.
- Tests: new tests/RunRemoteTests.py that mock subprocess/site-config and exercise the above behaviors.

Testing
- New unit tests included; run CI to confirm they pass.
- Recommended staging validation: confirm misclassified jobs (previously OTHER) are now correctly reported as OOM when sacct has the record, and verify retries for tools using --rundir create/use distinct directories.

Risk / compatibility
- Conservative change: squeue output remains authoritative when present; sacct is used only when squeue cannot classify.
- Low-to-medium risk because this affects job-classification and retry behavior globally.
- Note: rundir redirection uses a simple regex on the `--rundir` token; if callers use complex quoting or alternative CLI forms, consider a follow-up using shlex-based parsing.

Release note
- Fix job-status classification by falling back to sacct when squeue can’t classify (preserves OOM detection).
- Ensure retries use unique rundirs to avoid FileExistsError in downstream tools.